### PR TITLE
Update menu.py

### DIFF
--- a/config/hardening/menu.py
+++ b/config/hardening/menu.py
@@ -904,7 +904,7 @@ class Display_Menu:
 			f.write('autoconf\n')
 			f.write('make\n')
 			f.write('libstdc++\n')
-			f.write('compat-libstdc++\n')
+			f.write('compat-libstdc++-33\n')
 			f.write('libaio\n')
 			f.write('libaio-devel\n')
 			f.write('unixODBC\n')


### PR DESCRIPTION
Changed the package name under the "Proprietary Database" selection from "compat-libstdc++" to "compat-libstdc++-33" to fix the "Missing Package: You have specified that the package 'compat-libstdc++' should be installed.  This package does not exist. Would you like to continue or abort this installation?" error on installation.